### PR TITLE
Use standalone traitlets

### DIFF
--- a/oauthenticator.py
+++ b/oauthenticator.py
@@ -18,7 +18,7 @@ from jupyterhub.handlers import BaseHandler
 from jupyterhub.auth import Authenticator, LocalAuthenticator
 from jupyterhub.utils import url_path_join
 
-from IPython.utils.traitlets import Unicode
+from traitlets import Unicode
 
 class GitHubMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"


### PR DESCRIPTION
jupyter/jupyterhub#261 removes the dependency on IPython.utils.traitlets. This PR uses the standalone traitlets directly.