### PR TITLE
Enable requesting a specific OAuth scope in subclasses

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -21,6 +21,7 @@ class OAuthLoginHandler(BaseHandler):
     
     Typically subclasses will need
     """
+    scope = []
 
     def get(self):
         guess_uri = '{proto}://{host}{path}'.format(
@@ -38,7 +39,7 @@ class OAuthLoginHandler(BaseHandler):
         self.authorize_redirect(
             redirect_uri=redirect_uri,
             client_id=self.authenticator.client_id,
-            scope=[],
+            scope=self.scope,
             response_type='code')
 
 


### PR DESCRIPTION
This change enables subclasses of `OAuthenticator` to request access to a specific scope during authorization.

FYI, this is the first of a couple PRs I plan on making to Jupyter repos to move [How to Whale's](https://github.com/carolynvs/howtowhale) JupyterHub Carina support into the official repos. So if I'm goofing up anything, please let me know so that I'm not causing any extra trouble for you all.